### PR TITLE
Don't redirect to displayqr if resource is not google_authenticatable

### DIFF
--- a/lib/devise_google_authenticatable/patches/display_qr.rb
+++ b/lib/devise_google_authenticatable/patches/display_qr.rb
@@ -16,7 +16,12 @@ module DeviseGoogleAuthenticator::Patches
             set_flash_message :notice, :signed_up if is_flashing_format?
             sign_in(resource_name, resource)
             
-            respond_with resource, :location => {:controller => 'displayqr', :action => 'show'}
+            if resource.respond_to? :gauth_enabled?
+              respond_with resource, :location => {:controller => 'displayqr', :action => 'show'}
+            else
+              respond_with resource, location: after_sign_up_path_for(resource)
+            end
+
           else
             set_flash_message :notice, :"signed_up_but_#{resource.inactive_message}" if is_flashing_format?
             expire_data_after_sign_in!


### PR DESCRIPTION
**Problem**: I want to use google authenticator with activeadmin, but as soon as I install the gem and set it up for the AdminUser model, my regular users get redirected to the displayqr page on user signup.

**Solution**: This patch checks if the particular resource is google_authenticatable before redirecting. If not, it follows default devise behavior.

I suspect there's a cleaner way to find out if a resource is configured to be :google_authenticatable, but I'm not too familiar with the internals of devise. Still, this patch makes logical sense to me. I suspect another change or two is probably necessary to prevent it from interfering with regular users.

Overall though, thanks so much for the google_authenticator module! This will likely save a lot of time. Great work.

Thoughts?
