### PR TITLE
Ability to set an Issuer

### DIFF
--- a/lib/devise_google_authenticatable/controllers/helpers.rb
+++ b/lib/devise_google_authenticatable/controllers/helpers.rb
@@ -1,10 +1,11 @@
 module DeviseGoogleAuthenticator
   module Controllers # :nodoc:
     module Helpers # :nodoc:
-      def google_authenticator_qrcode(user,qualifier=nil)
+      def google_authenticator_qrcode(user, qualifier=nil, issuer=nil)
         username = username_from_email(user.email)
         app = Rails.application.class.parent_name
         data = "otpauth://totp/#{otpauth_user(username, app, qualifier)}?secret=#{user.gauth_secret}"
+        data << "&issuer=#{issuer}" if !issuer.nil?
         data = Rack::Utils.escape(data)
         url = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=#{data}"
         return image_tag(url, :alt => 'Google Authenticator QRCode')

--- a/test/lib/devise_google_authenticatable/controllers/helpers_test.rb
+++ b/test/lib/devise_google_authenticatable/controllers/helpers_test.rb
@@ -19,4 +19,15 @@ class HelpersTest < ActiveSupport::TestCase
     test 'can get otpauth_user with a qualifier' do
         assert_equal "username@app-qualifier", otpauth_user('username', 'app', '-qualifier')
     end
+
+    # fake image tag
+    def image_tag(src, *args)
+        src
+    end
+    test 'generate qrcode' do
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsApp%3Fsecret%3D", google_authenticator_qrcode(@user)
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsAppMyQualifier%3Fsecret%3D", google_authenticator_qrcode(@user, 'MyQualifier')
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsApp%3Fsecret%3D%26issuer%3DMyIssuer", google_authenticator_qrcode(@user, nil, 'MyIssuer')
+        assert_equal "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=otpauth%3A%2F%2Ftotp%2Fhelpers_test%40RailsAppMyQualifier%3Fsecret%3D%26issuer%3DMyIssuer", google_authenticator_qrcode(@user, 'MyQualifier', 'MyIssuer')
+    end
 end


### PR DESCRIPTION
The issuer parameter is a string value indicating the provider or service this account is associated with, URL-encoded according to RFC 3986. If the issuer parameter is absent, issuer information may be taken from the issuer prefix of the label. If both issuer parameter and issuer label prefix are present, they should be equal. (https://code.google.com/p/google-authenticator/wiki/KeyUriFormat#Issuer)
