### PR TITLE
[feature] handle namespaced devise models 

### DIFF
--- a/lib/devise_google_authenticatable/patches/check_ga.rb
+++ b/lib/devise_google_authenticatable/patches/check_ga.rb
@@ -7,6 +7,12 @@ module DeviseGoogleAuthenticator::Patches
 
       alias_method :create_original, :create
 
+      define_method :checkga_resource_path_name do |resource, id|
+        name = resource.class.name.singularize.underscore
+        name = name.split('/').last
+        "#{name}_checkga_path(id:'#{id}')"
+      end
+
       define_method :create do
 
         resource = warden.authenticate!(:scope => resource_name, :recall => "#{controller_path}#new")
@@ -18,7 +24,7 @@ module DeviseGoogleAuthenticator::Patches
           #we head back into the checkga controller with the temporary id
           #Because the model used for google auth may not always be the same, and may be a sub-model, the eval will evaluate the appropriate path name
           #This change addresses https://github.com/AsteriskLabs/devise_google_authenticator/issues/7
-          respond_with resource, :location => eval("#{resource.class.name.singularize.underscore}_checkga_path(id:'#{tmpid}')")
+          respond_with resource, :location => eval(checkga_resource_path_name(resource, tmpid))
 
         else #It's not using, or not enabled for Google 2FA, OR is remembering token and therefore not asking for the moment - carry on, nothing to see here.
           set_flash_message(:notice, :signed_in) if is_flashing_format?

--- a/test/lib/patches/check_ga_test.rb
+++ b/test/lib/patches/check_ga_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+require 'devise_google_authenticatable/patches/check_ga.rb'
+
+class MockCheckGA
+  def create
+  end
+
+  include DeviseGoogleAuthenticator::Patches::CheckGA
+end
+
+module Nested
+  class Admin
+  end
+end
+
+class User
+end
+
+class CheckGaTest < ActiveSupport::TestCase
+
+    test 'handles namespaces' do
+      assert_equal "admin_checkga_path(id:'1')", MockCheckGA.new.checkga_resource_path_name(Nested::Admin.new, 1)
+    end
+    test 'handles non-namespaced paths' do
+      assert_equal "user_checkga_path(id:'1')", MockCheckGA.new.checkga_resource_path_name(User.new, 1)
+    end
+end


### PR DESCRIPTION
My devise user is namespaced as **Admin::Admin** (under a Rails Engine).  This created an issue where **admin/admin_createga_path** was evaled.  

This is a fix for this namespace issue.
