### PR TITLE
Add disabled/enabled messages to displayqr locales

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,3 +17,5 @@ en:
       user:
         status: "User status updated!"
         newtoken: "You have updated to a new token - make sure you update your Google Authenticator application before continuing!!"
+        disabled: "Two-factor authentication has been disabled."
+        enabled: "Two-factor authentication has been enabled."


### PR DESCRIPTION
I was getting errors about translations missing in for `en.devise.displayqr.user` when enabling or disabling 2fa from /displayqr. I added enabled/disabled messages to fix that.