### PR TITLE
update ROTP version

### DIFF
--- a/devise_google_authenticator.gemspec
+++ b/devise_google_authenticator.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     # 'actionmailer' => '>= 3.0', 
     'actionmailer' => '>= 3.2.12',
     'devise' => '>= 3.2.0',
-    'rotp'   => '~> 1.4.0'
+    'rotp'   => '~> 1.6.1'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)
   end


### PR DESCRIPTION
I was really annoyed by constant warnings `Digest::Digest is deprecated; use Digest`. It was fixed already in the  [ROTP gem](https://github.com/mdp/rotp), so I thought - why can't we use that.

soo.. here's my PR - tests are the same as before updating the gem. 

I've tried also with `'rotp   => '~> 2.0.0'`, but it breaks one of the tests.
