### PR TITLE
[Rails 5.1] Compatibility with Rails 5.1

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,9 +21,9 @@ Install Devise:
 Setup the User or Admin model
 * rails g devise MODEL
 
-Configure your app for authorisation, edit your Controller and add this before_filter:
+Configure your app for authorisation, edit your Controller and add this before_action:
 
-* before_filter :authenticate_user!
+* before_action :authenticate_user!
 
 Make sure your "root" route is configured in config/routes.rb
 

--- a/app/controllers/devise/checkga_controller.rb
+++ b/app/controllers/devise/checkga_controller.rb
@@ -1,6 +1,6 @@
 class Devise::CheckgaController < Devise::SessionsController
-  prepend_before_filter :devise_resource, :only => [:show]
-  prepend_before_filter :require_no_authentication, :only => [ :show, :update ]
+  prepend_before_action :devise_resource, :only => [:show]
+  prepend_before_action :require_no_authentication, :only => [ :show, :update ]
 
   include Devise::Controllers::Helpers
 

--- a/app/controllers/devise/displayqr_controller.rb
+++ b/app/controllers/devise/displayqr_controller.rb
@@ -1,5 +1,5 @@
 class Devise::DisplayqrController < DeviseController
-  prepend_before_filter :authenticate_scope!, :only => [:show, :update, :refresh]
+  prepend_before_action :authenticate_scope!, :only => [:show, :update, :refresh]
 
   include Devise::Controllers::Helpers
 

--- a/devise_google_authenticator.gemspec
+++ b/devise_google_authenticator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
     # removed the following to try and get past this bundle update not finding compatible versions for gem issue
     # 'actionmailer' => '>= 3.0', 
     #'actionmailer' => '~> 3.2',# '>= 3.2.12',
-    'devise' => '~> 3.2',
+    'devise' => '~> 4.4.0',
     'rotp'   => '~> 1.6'
   }.each do |lib, version|
     s.add_runtime_dependency(lib, *version)

--- a/lib/devise_google_authenticatable/rails.rb
+++ b/lib/devise_google_authenticatable/rails.rb
@@ -1,6 +1,6 @@
 module DeviseGoogleAuthenticator
   class Engine < ::Rails::Engine # :nodoc:
-    ActionDispatch::Callbacks.to_prepare do
+    ActiveSupport::Reloader.to_prepare do
       DeviseGoogleAuthenticator::Patches.apply
     end
 

--- a/test/rails_app/app/controllers/application_controller.rb
+++ b/test/rails_app/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
 class ApplicationController < ActionController::Base
   # protect_from_forgery
-  before_filter :authenticate_user!
+  before_action :authenticate_user!
 end


### PR DESCRIPTION
This is related to Rails 5 upgrade on Harrys codebase and https://github.com/harrystech/cacheable-flash-mootools-harrys/pull/3 
Changes:
1. Use `before_action` instead of `before_filter`
2. Use `prepend_before_action` instead of `prepend_before_filter`. Filter callbacks are renamed for readability in Rails 5. There is no change in behavior.